### PR TITLE
fix(build): include `stdexcept` in state source

### DIFF
--- a/table/src/state.cpp
+++ b/table/src/state.cpp
@@ -4,6 +4,7 @@
 #include "../../grammar/include/symbol.hpp"
 #include "../../grammar/include/token.hpp"
 #include <utility>
+#include <stdexcept>
 
 using namespace asparserations;
 using namespace grammar;


### PR DESCRIPTION
When compiling in Arch Linux with `make install`, G++ raises an error:
```
mkdir -p build
g++ -std=c++11 -c -o build/gen_json.o bootstrap/src/gen_json.cpp
g++ -std=c++11 -c -o build/grammar.o grammar/src/grammar.cpp
g++ -std=c++11 -c -o build/nonterminal.o grammar/src/nonterminal.cpp
g++ -std=c++11 -c -o build/token.o grammar/src/token.cpp
g++ -std=c++11 -c -o build/production.o grammar/src/production.cpp
g++ -std=c++11 -c -o build/table.o table/src/table.cpp
g++ -std=c++11 -c -o build/lr_table.o table/src/lr_table.cpp
g++ -std=c++11 -c -o build/lalr_table.o table/src/lalr_table.cpp
g++ -std=c++11 -c -o build/item_set.o table/src/item_set.cpp
g++ -std=c++11 -c -o build/item.o table/src/item.cpp
g++ -std=c++11 -c -o build/state.o table/src/state.cpp
table/src/state.cpp: In member function ‘void asparserations::table::State::add_transition(const asparserations::grammar::Symbol*, const asparserations::table::State*)’:
table/src/state.cpp:25:18: error: ‘runtime_error’ is not a member of ‘std’
   25 |       throw std::runtime_error("Bad cast from const Symbol* to const Token*");
      |                  ^~~~~~~~~~~~~
table/src/state.cpp:31:18: error: ‘runtime_error’ is not a member of ‘std’
   31 |       throw std::runtime_error(
      |                  ^~~~~~~~~~~~~
make: *** [Makefile:94: build/state.o] Error 1
``` 
The same occurs with `clang++`.